### PR TITLE
remove dropped option "celery"

### DIFF
--- a/8.22/docker-entrypoint.sh
+++ b/8.22/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 case "$1" in
-	celery|cleanup|config|createuser|devserver|django|exec|export|help|import|init|plugins|queues|repair|run|shell|start|tsdb|upgrade)
+	cleanup|config|createuser|devserver|django|exec|export|help|import|init|plugins|queues|repair|run|shell|start|tsdb|upgrade)
 		set -- sentry "$@"
 	;;
 esac


### PR DESCRIPTION
I found the right start celery command is " run worker"